### PR TITLE
Fixed the decode function

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -193,7 +193,10 @@ std::string decode(std::string text) {
 	// We convert the ASCII to char
 	std::string output;
 	for (int i = 0; i < bits.size(); i++) {
-		output += char(bits[i]);
+		// Only convert the ASCII to char if it's not a padding zero.
+		if (bits[i] != 0) {
+			output += char(bits[i]);
+		}
 	}
 
 	// Return the output
@@ -232,8 +235,14 @@ int main() {
 		std::cout << "\nTime span: " << time_span.count() << "s\n";
 
 		// Pause and clear screen
-		system("pause");
-		system("cls");
+		#ifdef _WIN32 // If we're running on Windows.
+			system("pause");
+			system("cls");
+		#else // Linux or MacOS.
+			std::cout << "Press [Enter] to continue.. ";
+			std::cin.ignore();
+			system("clear");
+		#endif
 	}
 
 	return 0;


### PR DESCRIPTION
I've made a little fix for your conversion from ASCII to char in the decode function, and added a Linux and MacOS support for the code.

For the fix, here is an example:
* Encoding "1234" gives "MTIzNA==".
* Then, decoding "MTIzNA==" results in "31 32 33 34 00 00" in hex representation and "1234" in output, causing a length mismatch.
* So, instead of having a length of 4, the length is 6 due to the added "00 00" padding.
* If I compare "1234" and "decode(MTIzNA==)" (which returns "1234" too), the program says that it's unequal because of the length difference.

Have a good day!